### PR TITLE
Updated forum.css for better CJK chars display

### DIFF
--- a/css/Forum.css
+++ b/css/Forum.css
@@ -455,7 +455,7 @@ table.postHeader td.gotoButtonEnd a {
 		}
 
 			div.posterContent div.postType p {
-				font-size: 11px;
+				font-size: 12px;
 				line-height: 14px;
 			}
 


### PR DESCRIPTION
changed "div.postType p" font-size to 12px, because the previous 11px was too small for some non-latin chars (e.g., Chinese chars) to display, see https://zh-cn.libreoffice.org/help/forum/libreoffice/show/91#post91 for the ugly example.
